### PR TITLE
Remove potential side effects from `get_average_entropy` function

### DIFF
--- a/colocationpy/metrics.py
+++ b/colocationpy/metrics.py
@@ -202,9 +202,9 @@ def get_average_entropy(data: pd.DataFrame) -> float:
     float
         The mean entropy for the interactions identified.
     """
-    data["species_pair"] = data.apply(__get_species_pair, axis=1)
+    pairs = data.apply(__get_species_pair, axis=1)
 
-    pair_counts = data["species_pair"].value_counts()
+    pair_counts = pairs.value_counts()
 
     total_interactions = pair_counts.sum()
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -2,14 +2,26 @@
 Set of tests for the metrics calculated in this package.
 """
 
+import math
+
+import numpy as np
 import pandas as pd
 import pytest
 
 from colocationpy.metrics import (  # get_average_entropy,; get_entropies,
     get_individual_entropies,
     get_mutual_information,
+    get_average_entropy,
 )
 
+CASES = {
+    # Three unordered pairs with equal frequency: H = log2(3)
+    "balanced_three": [("cat", "dog"), ("cat", "cat"), ("dog", "dog")],
+    # Frequencies: {("cat","dog"):2, ("cat","cat"):1, ("dog","dog"):1} ⇒ [0.5, 0.25, 0.25]
+    "skewed_three": [("cat", "dog"), ("cat", "dog"), ("cat", "cat"), ("dog", "dog")],
+    # Empty → 0.0 by definition
+    "empty": [],
+}
 # entropy_data = [
 #     (
 #         pd.DataFrame({"species_x": [1, 1, 2, 2], "species_y": [1, 2, 1, 2]}),
@@ -90,6 +102,22 @@ individual_entropies_data = [
 ]
 
 
+def make_df(pairs):
+    return pd.DataFrame(pairs, columns=["species_x", "species_y"])
+
+
+def expected_entropy_from_pairs(pairs) -> float:
+    if not pairs:
+        return 0.0
+    # Unordered species pairs (sorted tuple), matching the intended metric
+    ser = pd.Series([tuple(sorted(p)) for p in pairs])
+    counts = ser.value_counts()
+    total = int(counts.sum())
+    p = counts.values / total
+    # Shannon entropy base 2
+    return float(-(p * np.log2(p)).sum())
+
+
 @pytest.mark.parametrize("data, species_map, expected", individual_entropies_data)
 def test_get_individual_entropies(data, species_map, expected):
     entropies = get_individual_entropies(data, species_map)
@@ -123,21 +151,37 @@ def test_get_individual_entropies(data, species_map, expected):
 #     pd.testing.assert_series_equal(entropies, expected)
 
 
-# @pytest.mark.parametrize("data, expected", average_entropy_data)
-# def test_get_average_entropy(data: pd.DataFrame, expected: float):
-#     """
-#     Test the `get_average_entropy()` method.
+@pytest.mark.parametrize(
+    "case_name, expected",
+    [
+        ("balanced_three", math.log2(3)),
+        ("skewed_three", 1.5),
+        ("empty", 0.0),
+    ],
+)
+def test_get_average_entropy_expected_values(case_name, expected):
+    df = make_df(CASES[case_name])
+    got = get_average_entropy(df)
+    assert np.isclose(got, expected)
 
-#     Parameters
-#     ----------
-#     data : pd.DataFrame
-#         A DataFrame of co-location instances.
-#     expected : float
-#         The expected average entropy.
 
-#     """
-#     actual = get_average_entropy(data)
-#     assert actual == expected
+@pytest.mark.parametrize("case_name", list(CASES.keys()))
+def test_get_average_entropy_matches_reference(case_name):
+    pairs = CASES[case_name]
+    df = make_df(pairs)
+    ref = expected_entropy_from_pairs(pairs)
+    got = get_average_entropy(df)
+    assert np.isclose(got, ref)
+
+
+@pytest.mark.parametrize("case_name", ["balanced_three", "skewed_three"])
+def test_get_average_entropy_no_mutation(case_name):
+    df = make_df(CASES[case_name])
+    df_before = df.copy(deep=True)
+    _ = get_average_entropy(df)
+    # No extra columns, same data
+    assert list(df.columns) == list(df_before.columns)
+    assert df.equals(df_before)
 
 
 @pytest.mark.parametrize("data, expected", mutual_information_data)


### PR DESCRIPTION
- Stop mutating call
- Improve tests for `get_average_entropy`